### PR TITLE
Don't prefix host-less redirects that are not Accounts paths

### DIFF
--- a/lib/openstax/path_prefixer/action_controller_base_extensions.rb
+++ b/lib/openstax/path_prefixer/action_controller_base_extensions.rb
@@ -12,8 +12,23 @@ ActionController::Base.class_exec do
       options
     when String
       ##### BEGIN MODIFICATION FROM ORIGINAL RAILS CODE #####
-      # Add the script name prefix unless it is alread there
-      options = "#{request.script_name}#{options}" unless options.match(/^#{request.script_name}/)
+      # Add the script name prefix unless it is already there or
+      # if the path is not an app route path
+      if request.script_name.present?
+        already_has_prefix = options.match(/^#{request.script_name}/)
+
+        unless already_has_prefix
+          options_uri = URI(options)
+
+          path_matches_a_route = Rails.application.routes.set.any? do |route|
+            route.path.match(options_uri.path)
+          end
+
+          if path_matches_a_route
+            options = "#{request.script_name}#{options}"
+          end
+        end
+      end
       ##### END MODIFICATION FROM ORIGINAL RAILS CODE   #####
 
       request.protocol + request.host_with_port + options

--- a/spec/dummy/app/controllers/dummy_controller.rb
+++ b/spec/dummy/app/controllers/dummy_controller.rb
@@ -31,6 +31,10 @@ class DummyController < ApplicationController
     redirect_to proc { an_action_url }
   end
 
+  def hostless_non_accounts_redirect
+    redirect_to "/books/physics"
+  end
+
   def a_prefix_blah
   end
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     get :external_redirect
     get :a_prefix_blah
     get :a_prefix_blah_redirect
+    get :hostless_non_accounts_redirect
   end
 
   get '', to: "dummy#root"

--- a/spec/requests/redirect_spec.rb
+++ b/spec/requests/redirect_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe 'redirects', type: :request do
       expect(URI(response.location).path).to eq "/a_prefix/an_action"
     end
 
+    it "should not prefix a host-less redirect that doesn't match a route" do
+      get("/a_prefix/hostless_non_accounts_redirect")
+      expect(URI(response.location).path).to eq "/books/physics"
+    end
+
   end
 
   context "when incoming request does not have the prefix" do


### PR DESCRIPTION
Changes the library to not prefix redirects that are host-less but that do not match an Accounts route.  Used in a system that proxies Accounts where not all host-less redirects belong to Accounts.