### PR TITLE
base prefix avoidance on redirects on route verb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ else
 end
 
 gem "rails", rails
+
+gem "an_engine", path: "./spec/an_engine"

--- a/lib/openstax/path_prefixer/action_controller_base_extensions.rb
+++ b/lib/openstax/path_prefixer/action_controller_base_extensions.rb
@@ -21,6 +21,7 @@ ActionController::Base.class_exec do
           options_uri = URI(options)
 
           path_matches_a_route = Rails.application.routes.set.any? do |route|
+            "GET".match(route.verb) &&
             route.path.match(options_uri.path)
           end
 

--- a/spec/an_engine/an_engine.gemspec
+++ b/spec/an_engine/an_engine.gemspec
@@ -1,0 +1,23 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "an_engine/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = "an_engine"
+  s.version     = AnEngine::VERSION
+  s.authors     = ["JP Slavinsky"]
+  s.email       = ["jpslav@gmail.com"]
+  s.homepage    = "https://notapplicable.org"
+  s.summary     = "n/a"
+  s.description = "n/a"
+  s.license     = "MIT"
+
+  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.test_files = Dir["test/**/*"]
+
+  s.add_dependency "rails", ">= 4.2"
+
+  s.add_development_dependency "sqlite3"
+end

--- a/spec/an_engine/app/controllers/an_engine/application_controller.rb
+++ b/spec/an_engine/app/controllers/an_engine/application_controller.rb
@@ -1,0 +1,9 @@
+module AnEngine
+  class ApplicationController < ActionController::Base
+    protect_from_forgery with: :exception
+
+    def options
+      head :ok
+    end
+  end
+end

--- a/spec/an_engine/config/routes.rb
+++ b/spec/an_engine/config/routes.rb
@@ -1,0 +1,3 @@
+AnEngine::Engine.routes.draw do
+  match "/*all" => 'application#options',  via: [:options]
+end

--- a/spec/an_engine/lib/an_engine.rb
+++ b/spec/an_engine/lib/an_engine.rb
@@ -1,0 +1,4 @@
+require "an_engine/engine"
+
+module AnEngine
+end

--- a/spec/an_engine/lib/an_engine/engine.rb
+++ b/spec/an_engine/lib/an_engine/engine.rb
@@ -1,0 +1,5 @@
+module AnEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace AnEngine
+  end
+end

--- a/spec/an_engine/lib/an_engine/version.rb
+++ b/spec/an_engine/lib/an_engine/version.rb
@@ -1,0 +1,3 @@
+module AnEngine
+  VERSION = "0.0.1"
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+
+  mount AnEngine::Engine, at: '/'
+
   scope controller: :dummy do
     get :an_action
     get :local_redirect_via_action

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
   get '', to: "dummy#root"
 
+  match 'books/physics', to: "dummy#root", via: [:options]
+
   resources :url_helper, only: [] do
     get :an_action, on: :collection
     get :another_action, on: :collection


### PR DESCRIPTION
In https://github.com/openstax/path_prefixer/pull/3 we changed to only prefix redirects that matched routes in the app.  But we didn't check for a verb match, which meant we were over-prefixing.  This adds the verb check.